### PR TITLE
Add Wei local load-sharing cascade model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added `model='local_load_sharing'`, implementing degree-weighted local redistribution with `beta=0` for equal sharing and larger values favoring higher-degree neighbors.
+- Local cascade states now report load that cannot reach a functioning neighbor as `shed_load`.
+- Added analytical regressions for initialization, equal and preferential allocation, synchronous updates, stranded load, and parameter validation.
+
 ## 0.4.0 - Crucitti model and modern Python
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.0 - Local load-sharing cascades
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -302,8 +302,10 @@ Beygelzimer *et al.* [Improving network robustness by edge modification](https:/
 
 
 **Simulation Frameworks:**
-* **[Cascading Failure Model](https://graph-tiger.readthedocs.io/en/latest/cascading.html#graph_tiger.cascading.Cascading)** 
-<br> Motter and Lai [Cascade-based attacks on complex networks](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.66.065102) (Physical Review E 2002)
+* **[Cascading Failure Models](https://graph-tiger.readthedocs.io/en/latest/cascading.html#graph_tiger.cascading.Cascading)**
+  * Motter and Lai [Cascade-based attacks on complex networks](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.66.065102) (Physical Review E 2002)
+  * Crucitti, Latora, and Marchiori [Model for cascading failures in complex networks](https://doi.org/10.1103/PhysRevE.69.045104) (Physical Review E 2004)
+  * Wei, Luo, and Zhang [Analysis of cascading failure in complex power networks under the load local preferential redistribution rule](https://doi.org/10.1016/j.physa.2011.12.030) (Physica A 2012)
 * **[Susceptible-Infected-Susceptible (SIS) Model](https://graph-tiger.readthedocs.io/en/latest/diffusion.html#graph_tiger.diffusion.Diffusion)** 
 <br> Pastor-Satorras and Vespignani [Epidemic spreading in scale-free networks](https://doi.org/10.1103/PhysRevLett.86.3200) (Physical Review Letters 2001)
 * **[Susceptible-Infected-Recovered (SIR) Model](https://graph-tiger.readthedocs.io/en/latest/diffusion.html#graph_tiger.diffusion.Diffusion)** 

--- a/docs/source/cascading.rst
+++ b/docs/source/cascading.rst
@@ -1,7 +1,7 @@
 Cascading
 =========
 
-``Cascading`` supports three explicitly named models.
+``Cascading`` supports three primary models and one compatibility model.
 
 ``motter_lai``
     The default node-overload model. Initial shortest-path load determines
@@ -14,17 +14,61 @@ Cascading
     distribution. Overloaded nodes remain active, but every incident edge is
     assigned the capacity-to-load efficiency ratio. Traffic is synchronously
     rerouted over the most efficient weighted paths. The result at each step is
-    average network efficiency, so it is already normalized to the interval
-    from 0 to 1. In TIGER, ``1 + r`` is the paper's tolerance parameter and
-    ``r`` must be positive.
+    average network efficiency. In TIGER, ``1 + r`` is the paper's tolerance
+    parameter and ``r`` must be positive.
+
+``local_load_sharing``
+    The local preferential redistribution model of
+    :cite:`wei2012analysis`. Initial node load is degree and fixed capacity is
+    :math:`C_i=(1+r)L_i(0)`. When node :math:`i` fails, its complete current
+    load is distributed among its functioning neighbors :math:`N_i^+`:
+
+    .. math::
+
+       \Delta L_{i\rightarrow j}
+       =
+       L_i
+       \frac{k_j^\beta}
+       {\sum_{u\in N_i^+} k_u^\beta}.
+
+    The degree :math:`k_j` is measured in the intact graph. The update is
+    synchronous: all transfers in one round are accumulated before new
+    overloads are identified. If a failed node has no functioning neighbor, its
+    load is recorded as ``shed_load``.
+
+    The exponent ``beta`` controls the allocation. With ``beta=0``, all
+    weights equal one and the model reduces to equal sharing. With ``beta=1``,
+    load is proportional to degree; larger values concentrate more load on
+    high-degree neighbors. For a failed load of 12 and neighbors with degrees
+    1, 2, and 3, ``beta=0`` assigns 4 to each neighbor, whereas ``beta=1``
+    assigns 2, 4, and 6.
 
 ``legacy_redistribution``
-    The corrected historical TIGER redistribution rule. It is TIGER-specific
-    and is not presented as either published model.
+    The corrected historical TIGER redistribution rule. It retains the former
+    random betweenness-based initialization for compatibility and is not
+    presented as a published model.
 
 All models preserve the caller-owned graph and return the attacked state at
 index 0 followed by one state per requested transition. Crucitti state records
-also expose ``overloaded`` nodes and ``edge_efficiency`` values.
+also expose ``overloaded`` nodes and ``edge_efficiency`` values. Local
+load-sharing records expose cumulative ``shed_load``.
+
+A local load-sharing simulation can be created directly:
+
+.. code-block:: python
+
+   cascade = Cascading(
+       graph,
+       model='local_load_sharing',
+       beta=1,
+       r=0.2,
+       attack='id_node',
+       k_a=1,
+       runs=1,
+       steps=20,
+       seed=7
+   )
+   trajectory = cascade.run_single_sim()
 
 .. automodule:: graph_tiger.cascading
    :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = 'Scott Freitas'
 copyright = '{}, {}'.format(datetime.datetime.now().year, author)
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.3'
+release = '0.5.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -845,3 +845,15 @@
   year={1927},
   publisher={The Royal Society London}
 }
+
+@article{wei2012analysis,
+  title={Analysis of cascading failure in complex power networks under the load local preferential redistribution rule},
+  author={Wei, Du Qu and Luo, Xiao Shu and Zhang, Bo},
+  journal={Physica A: Statistical Mechanics and its Applications},
+  volume={391},
+  number={8},
+  pages={2771--2777},
+  year={2012},
+  doi={10.1016/j.physa.2011.12.030},
+  publisher={Elsevier}
+}

--- a/docs/source/tutorials/tutorial-4.rst
+++ b/docs/source/tutorials/tutorial-4.rst
@@ -1,153 +1,97 @@
 Tutorial 4: Cascading Failures
 =========================================
 
-Cascading failures often arise as a result of natural failures or targeted attacks in a network. Consider an electrical grid where a central substation goes offline. In order to maintain the distribution of power, neighboring substations have to increase production in order to meet demand. However, if this is not possible, the neighboring substation fails, which in turn causes additional neighboring substations to fail. The end result is a series of cascading failures i.e., a blackout. While cascading failures can occur in a variety of network types e.g., water, electrical, communication, we focus on the electrical grid. Below, we discuss the design and implementation of the cascading failure model and how TIGER can be used to both **induce** and **prevent** cascading failures using the attack and defense mechanisms discussed in previous tutorials. There are 3 main processes governing the network simulation:
+A cascade begins with an initial component failure and continues when the
+resulting change in load overloads additional components. The appropriate TIGER
+model depends on how load moves after the trigger.
 
-- **capacity** of each node :math:`c_v\in [0,1]`
-- **load** of each node :math:`l_v\in U(0, l_{max})` 
-- network **redundancy** :math:`r\in [0, 1]`
+- ``motter_lai`` recomputes global shortest-path load and removes overloaded nodes.
+- ``crucitti`` reroutes over most-efficient paths and degrades service through
+  congested nodes without removing them.
+- ``local_load_sharing`` transfers a failed node's load only to its functioning
+  neighbors.
 
-The capacity of each node :math:`c_v` is the the maximum load a node can handle, which is set based on the node's normalized betweenness centrality. The load of each node :math:`l_v` represents the fraction of maximum capacity :math:`c_v` that the node operates at. Load for each node :math:`c_v` is set by uniformly drawing from :math:`U(0, l_{max})`, where :math:`l_{max}` is the maximum initial load. Network redundancy *r* represents the amount of reserve capacity present in the network i.e., auxiliary support systems. At the beginning of the simulation, we allow the user to attack and defend the network according to the node attack and defense strategies discussed in previous tutorials. When a node is attacked it becomes "overloaded", causing it to fail and requiring the load be distributed to its neighbors. When defending a node we increase it's capacity to protect against attacks.
+Local load sharing
+------------------
 
+The local model follows the degree-weighted redistribution rule of
+:cite:`wei2012analysis`. A node starts with load equal to its intact degree and
+capacity :math:`(1+r)L_i(0)`. When it fails, a neighboring node :math:`j`
+receives
 
-.. figure:: ../../../images/cascading-failure.jpg
-   :width: 100 %
-   :align: center
+.. math::
 
-   TIGER cascading failure simulation on the US power grid network when 4 nodes are overloaded according to the ID attack strategy. Time step 1: shows the network under normal conditions. Time step 50: we observe a series of failures originating from the bottom of the network. Time step 70: most of the network has collapsed.
+   \Delta L_{i\rightarrow j}
+   =
+   L_i
+   \frac{k_j^\beta}
+   {\sum_{u\in N_i^+} k_u^\beta}.
 
-To help users visualize cascading failures induced by targeted attacks, we enable them to create visuals like the figure above, where we overload 4 nodes selected by the ID attack strategy on the US power grid dataset (:math:`l_max=0.8`). Nodesize represents capacity i.e., larger size :math:`\rightarrow` higher capacity, and color indicates the load of each node on a gradient scale from blue (low load) to red (high load); dark red indicates node failure (overloaded). Time step 1 shows the network under normal conditions; at step 50 we observe a series of failures originating from the bottom of the network; by step 70 most of the network has collapsed. 
+With ``beta=0``, every functioning neighbor receives the same share. With
+``beta=1``, a neighbor of degree 3 receives three times as much as a neighbor
+of degree 1. Larger values concentrate the failed load more strongly on
+high-degree neighbors.
 
-
-To run a cascading failure simulations and create the visual, we just have to write a few lines of code:
+The following simulation attacks one high-degree node and applies linear
+degree preference:
 
 .. code-block:: python
-   :name: cascading-failure-1
+   :name: local-load-sharing
 
    from graph_tiger.cascading import Cascading
    from graph_tiger.graphs import graph_loader
-   
+
    graph = graph_loader('electrical')
+   cascade = Cascading(
+       graph,
+       model='local_load_sharing',
+       beta=1,
+       r=0.2,
+       attack='id_node',
+       k_a=1,
+       defense=None,
+       k_d=0,
+       runs=1,
+       steps=20,
+       seed=7,
+       plot_transition=False,
+       gif_animation=False
+   )
 
-   params = {
-      'runs': 1,
-      'steps': 100,
-      'seed': 1,
+   trajectory = cascade.run_single_sim()
+   failed_by_step = [cascade.sim_info[t]['failed']
+                     for t in range(len(trajectory))]
+   shed_by_step = [cascade.sim_info[t]['shed_load']
+                   for t in range(len(trajectory))]
 
-      'l': 0.8,
-      'r': 0.2,
-      'c': int(0.1 * len(graph)),
+Comparing equal and preferential sharing
+------------------------------------------
 
-      'k_a': 30,
-      'attack': 'rb_node',
-      'attack_approx': int(0.1 * len(graph)),
-
-      'k_d': 0,
-      'defense': None,
-
-      'robust_measure': 'largest_connected_component',
-
-      'plot_transition': True,  # False turns off key simulation image "snapshots"
-      'gif_animation': False,  # True creaets a video of the simulation (MP4 file)
-      'gif_snaps': False,  # True saves each frame of the simulation as an image
-
-      'edge_style': 'bundled',
-      'node_style': 'force_atlas',
-      'fa_iter': 2000,
-   }
-
-   cascading = Cascading(graph, **params)
-   results = cascading.run_simulation()
-
-   cascading.plot_results(results)
-
-
-We can also summarize simulation results over many configurations, and create plots the figure below, which shows the effect of network redundancy when 4 nodes are overloaded by the ID attack strategy. At 50% redundancy, we observe a critical threshold where the network is able to redistribute the increased load. For :math:`r < 50%`, the cascading failure can be delayed but not prevented.
-
-.. figure:: ../../../images/cascading-failure-comparison.jpg
-   :width: 75 %
-   :align: center
-
-   Effect of network redundancy *r* on the US power grid where 4 nodes are overloaded using ID. When :math:`r\geq 50\%` the network is able to redistribute the increased load.
-
-Running and visualizing multiple simulations only takes a few extra lines of code:
+Keep the graph, attack, capacity margin, and seed fixed, then change only
+``beta``:
 
 .. code-block:: python
-   :name: cascading-failure-comparison
+   :name: compare-local-sharing
 
-   params = {
-        'runs': 10,
-        'steps': 100,
-        'seed': 1,
+   results = {}
+   for beta in [0, 1, 2]:
+       cascade = Cascading(
+           graph, model='local_load_sharing', beta=beta, r=0.2,
+           attack='id_node', k_a=1, defense=None, k_d=0,
+           runs=1, steps=20, seed=7,
+           plot_transition=False, gif_animation=False
+       )
+       cascade.run_single_sim()
+       results[beta] = cascade.sim_info[20]['failed']
 
-        'l': 0.8,
-        'r': 0.2,
-        'c': int(0.1 * len(graph)),
+This comparison isolates the allocation rule. It does not assume that larger
+``beta`` is always safer: concentrating load on hubs can prevent low-degree
+neighbors from failing, but it can also overload an already stressed hub.
 
-        'k_a': 5,
-        'attack': 'id_node',
-        'attack_approx': None,  # int(0.1 * len(graph)),
+State and interpretation
+------------------------
 
-        'k_d': 0,
-        'defense': None,
-
-        'robust_measure': 'largest_connected_component',
-
-        'plot_transition': False,
-        'gif_animation': False,
-
-        'edge_style': None,
-        'node_style': 'spectral',
-        'fa_iter': 2000,
-
-    }
-
-    results = defaultdict(list)
-    redundancy = np.arange(0, 0.5, .1)
-
-    for idx, r in enumerate(redundancy):
-        params['r'] = r
-
-        if idx == 2:
-            params['plot_transition'] = True
-            params['gif_animation'] = True
-            params['gif_snaps'] = True
-        else:
-            params['plot_transition'] = False
-            params['gif_animation'] = False
-            params['gif_snaps'] = False
-
-        cf = Cascading(graph, **params)
-        results[r] = cf.run_simulation()
-
-    plot_results(graph, params, results, xlabel='Steps', line_label='Redundancy', experiment='redundancy')
-
-
-.. code-block:: python
-   :name: plot-results
-
-   def plot_results(graph, params, results, xlabel='Steps', line_label='', experiment=''):
-      plt.figure(figsize=(6.4, 4.8))
-
-      title = '{}:step={},l={},r={},k_a={},attack={},k_d={},defense={}'.format(experiment, params['steps'], params['l'], params['r'], params['k_a'],
-                                                                                    params['attack'], params['k_d'], params['defense'])
-      for strength, result in results.items():
-         result_norm = [r / len(graph) for r in result]
-         plt.plot(result_norm, label="{}: {}".format(line_label, strength))
-
-      plt.xlabel(xlabel)
-      plt.ylabel(params['robust_measure'])
-      plt.ylim(0, 1)
-
-      save_dir = os.getcwd() + '/plots/' + experiment + '/'
-      os.makedirs(save_dir, exist_ok=True)
-
-      plt.legend()
-      plt.title(title)
-      plt.savefig(save_dir + title + '.pdf')
-      plt.show()
-      plt.clf()
-
-
-
-
+The attacked state is recorded at index 0, followed by one state for each
+requested transition. ``failed`` gives the cumulative number of failed nodes.
+``status`` records node loads, and ``shed_load`` records load from failed nodes
+that had no functioning neighbor. The input graph is not modified.

--- a/graph_tiger/cascading.py
+++ b/graph_tiger/cascading.py
@@ -22,25 +22,35 @@ class Cascading(Simulation):
     over the most efficient weighted paths and results report average network
     efficiency :cite:`crucitti2004model`.
 
+    The local-load-sharing model gives node ``i`` initial load equal to its degree
+    and fixed capacity ``(1 + r) L_i(0)``. A failed node redistributes its complete
+    current load among functioning neighbors with weights proportional to
+    ``degree ** beta``. Thus ``beta=0`` gives equal sharing, while larger values
+    increasingly favor high-degree recipients :cite:`wei2012analysis`.
+
     The historical TIGER redistribution rule remains available as
     ``model='legacy_redistribution'``. It is a TIGER-specific model.
 
     :param graph: an undirected NetworkX graph
-    :param model: cascading model (``motter_lai``, ``crucitti``, or ``legacy_redistribution``)
+    :param model: cascading model (``motter_lai``, ``crucitti``, ``local_load_sharing``,
+        or ``legacy_redistribution``)
     :param runs: an integer number of times to run the simulation
     :param steps: an integer number of steps to run a single simulation
     :param l: a float representing the maximum initial load in the legacy model
     :param r: a float representing the amount of redundancy in the network
+    :param beta: a nonnegative degree-preference exponent for local load sharing
     :param **kwargs: see parent class Simulation for additional options
     """
 
-    def __init__(self, graph, model='motter_lai', runs=10, steps=100, l=0.8, r=0.2, **kwargs):
+    def __init__(self, graph, model='motter_lai', runs=10, steps=100, l=0.8, r=0.2,
+                 beta=0, **kwargs):
         super().__init__(graph, runs, steps, **kwargs)
 
         self.prm.update({
             'model': model,
             'l': l,
             'r': r,
+            'beta': beta,
             'c': len(graph),
 
             'robust_measure': 'largest_connected_component',
@@ -67,7 +77,10 @@ class Cascading(Simulation):
         self.save_dir = os.path.join(os.getcwd(), 'plots', self.get_plot_title(steps))
         os.makedirs(self.save_dir, exist_ok=True)
 
-        self.capacity_og = self.get_load(self.graph_og)
+        if self.prm['model'] == 'local_load_sharing':
+            self.capacity_og = dict(self.graph_og.degree())
+        else:
+            self.capacity_og = self.get_load(self.graph_og)
         self.max_val = max(self.capacity_og.values(), default=0) * (1.0 + self.prm['r'])
         self.prm['max_val'] = self.max_val
 
@@ -76,6 +89,7 @@ class Cascading(Simulation):
         self.failed_edges = set()
         self.processed = set()
         self.overloaded = set()
+        self.shed_load = 0
         self.load = {}
         self.sim_info = defaultdict()
 
@@ -86,17 +100,21 @@ class Cascading(Simulation):
         Validate cascading-model parameters.
         """
 
-        if self.prm['model'] not in ['motter_lai', 'crucitti', 'legacy_redistribution']:
-            raise ValueError("model must be 'motter_lai', 'crucitti', or 'legacy_redistribution'")
+        models = ['motter_lai', 'crucitti', 'local_load_sharing', 'legacy_redistribution']
+        if self.prm['model'] not in models:
+            raise ValueError('unknown cascading model')
         if self.prm['l'] < 0 or self.prm['l'] > 1:
             raise ValueError('l must satisfy 0 <= l <= 1')
         if self.prm['r'] < 0:
             raise ValueError('r must be nonnegative')
+        if self.prm['beta'] < 0:
+            raise ValueError('beta must be nonnegative')
         if self.prm['model'] == 'crucitti' and self.prm['r'] == 0:
             raise ValueError('r must be positive for the Crucitti model')
-        if self.prm['model'] == 'crucitti' and self.prm['attack'] is not None:
-            if get_attack_category(self.prm['attack']) != 'node':
-                raise ValueError('the Crucitti model requires a node attack')
+        if self.prm['model'] in ['crucitti', 'local_load_sharing']:
+            if self.prm['attack'] is not None:
+                if get_attack_category(self.prm['attack']) != 'node':
+                    raise ValueError('the selected cascading model requires a node attack')
         if len(self.graph_og) > 0 and self.prm['c'] is not None and self.prm['c'] <= 0:
             raise ValueError('c must be positive')
 
@@ -180,10 +198,11 @@ class Cascading(Simulation):
         self.failed_edges = set()
         self.processed = set()
         self.overloaded = set()
+        self.shed_load = 0
         self.sim_info = defaultdict()
         self.capacity = {n: (1.0 + self.prm['r']) * value for n, value in self.capacity_og.items()}
 
-        if self.prm['model'] in ['motter_lai', 'crucitti']:
+        if self.prm['model'] in ['motter_lai', 'crucitti', 'local_load_sharing']:
             self.load = self.capacity_og.copy()
         else:
             self.load = {}
@@ -262,6 +281,7 @@ class Cascading(Simulation):
             'overloaded': self.overloaded,
             'edge_efficiency': {(u, v): data.get('efficiency', 1)
                                 for u, v, data in self.graph.edges(data=True)},
+            'shed_load': self.shed_load,
             'measure': measure,
             'protected': self.protected
         }
@@ -318,6 +338,45 @@ class Cascading(Simulation):
 
         return changed
 
+    def run_local_load_sharing_step(self):
+        """
+        Redistribute newly failed loads using the Wei local preferential rule.
+
+        The degree weights come from the intact graph. Transfers from every
+        source in one round are accumulated before loads and failures are
+        updated, making the transition synchronous.
+
+        :return: set of nodes that fail in this step
+        """
+
+        sources = self.failed.difference(self.processed)
+        transfers = defaultdict(float)
+
+        for n in sources:
+            nbrs = set(self.graph.neighbors(n)).difference(self.failed)
+
+            if len(nbrs) == 0:
+                self.shed_load += self.load[n]
+            else:
+                weights = {nb: self.graph_og.degree(nb) ** self.prm['beta'] for nb in nbrs}
+                total_weight = sum(weights.values())
+
+                for nb in nbrs:
+                    transfers[nb] += self.load[n] * weights[nb] / total_weight
+
+            self.load[n] = 0
+
+        for n, value in transfers.items():
+            self.load[n] += value
+
+        self.processed.update(sources)
+
+        nodes_functioning = set(self.graph.nodes).difference(self.failed)
+        failed_new = {n for n in nodes_functioning if self.load[n] > self.capacity[n]}
+        self.failed.update(failed_new)
+
+        return failed_new
+
     def run_legacy_step(self):
         """
         Redistribute each newly failed node's load once among functioning neighbors.
@@ -360,6 +419,10 @@ class Cascading(Simulation):
 
                 elif self.prm['model'] == 'crucitti':
                     stable = not self.run_crucitti_step()
+
+                elif self.prm['model'] == 'local_load_sharing':
+                    failed_new = self.run_local_load_sharing_step()
+                    stable = len(failed_new) == 0
 
                 else:
                     failed_new = self.run_legacy_step()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import find_packages, setup
 
 # run "git tag <version>" and then "git push origin master <version> when releasing a package to PyPi
-version = "0.4.0"
+version = "0.5.0"
 
 keywords = ["data-science",
             "machine-learning",

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -525,6 +525,148 @@ def test_crucitti_validates_parameters():
 
         assert raised
 
+def test_local_load_sharing_initial_load_and_capacity():
+    params = get_simulation_params()
+    params.update({
+        'model': 'local_load_sharing',
+        'beta': 0,
+        'r': 0.5,
+        'k_a': 0,
+        'attack': None,
+        'k_d': 0,
+        'defense': None
+    })
+
+    graph = nx.path_graph(3)
+    cf = Cascading(graph, **params)
+
+    assert cf.load == dict(graph.degree())
+    assert cf.capacity == {0: 1.5, 1: 3, 2: 1.5}
+
+
+def test_local_load_sharing_equal_redistribution():
+    params = get_simulation_params()
+    params.update({
+        'model': 'local_load_sharing',
+        'beta': 0,
+        'r': 0.2,
+        'k_a': 0,
+        'attack': None,
+        'k_d': 0,
+        'defense': None
+    })
+
+    cf = Cascading(nx.star_graph(3), **params)
+    cf.load = {0: 12, 1: 0, 2: 0, 3: 0}
+    cf.capacity = {0: 0, 1: 10, 2: 10, 3: 10}
+    cf.failed = {0}
+    cf.processed = set()
+
+    failed_new = cf.run_local_load_sharing_step()
+
+    assert failed_new == set()
+    assert cf.load == {0: 0, 1: 4, 2: 4, 3: 4}
+    assert cf.shed_load == 0
+
+
+def test_local_load_sharing_degree_preference():
+    params = get_simulation_params()
+    params.update({
+        'model': 'local_load_sharing',
+        'beta': 1,
+        'r': 0.2,
+        'k_a': 0,
+        'attack': None,
+        'k_d': 0,
+        'defense': None
+    })
+
+    graph = nx.Graph([(0, 1), (0, 2), (0, 3), (2, 4), (3, 5), (3, 6)])
+    cf = Cascading(graph, **params)
+    cf.load = {n: 0 for n in graph.nodes}
+    cf.load[0] = 12
+    cf.capacity = {n: 20 for n in graph.nodes}
+    cf.failed = {0}
+    cf.processed = set()
+
+    cf.run_local_load_sharing_step()
+
+    assert cf.load[1] == 2
+    assert cf.load[2] == 4
+    assert cf.load[3] == 6
+
+
+def test_local_load_sharing_updates_synchronously():
+    params = get_simulation_params()
+    params.update({
+        'model': 'local_load_sharing',
+        'beta': 0,
+        'r': 0.2,
+        'k_a': 0,
+        'attack': None,
+        'k_d': 0,
+        'defense': None
+    })
+
+    graph = nx.Graph([(0, 2), (1, 2)])
+    cf = Cascading(graph, **params)
+    cf.load = {0: 4, 1: 6, 2: 0}
+    cf.capacity = {0: 0, 1: 0, 2: 9}
+    cf.failed = {0, 1}
+    cf.processed = set()
+
+    failed_new = cf.run_local_load_sharing_step()
+
+    assert failed_new == {2}
+    assert cf.load == {0: 0, 1: 0, 2: 10}
+
+
+def test_local_load_sharing_records_shed_load():
+    params = get_simulation_params()
+    params.update({
+        'model': 'local_load_sharing',
+        'beta': 0,
+        'r': 0.2,
+        'k_a': 0,
+        'attack': None,
+        'k_d': 0,
+        'defense': None
+    })
+
+    graph = nx.empty_graph(1)
+    cf = Cascading(graph, **params)
+    cf.load = {0: 5}
+    cf.capacity = {0: 0}
+    cf.failed = {0}
+    cf.processed = set()
+
+    cf.run_local_load_sharing_step()
+
+    assert cf.load[0] == 0
+    assert cf.shed_load == 5
+
+
+def test_local_load_sharing_validates_parameters():
+    params = get_simulation_params()
+    params.update({
+        'model': 'local_load_sharing',
+        'beta': -1,
+        'r': 0.2,
+        'k_a': 0,
+        'attack': None,
+        'k_d': 0,
+        'defense': None
+    })
+
+    raised = False
+    try:
+        Cascading(nx.path_graph(3), **params)
+    except ValueError:
+        raised = True
+
+    assert raised
+
+
 def test_legacy_cascading_redistributes_failed_load_once():
     params = get_simulation_params()
     params.update({
@@ -721,6 +863,12 @@ def main():
     test_crucitti_restores_edge_efficiency()
     test_crucitti_uses_weighted_efficient_paths()
     test_crucitti_validates_parameters()
+    test_local_load_sharing_initial_load_and_capacity()
+    test_local_load_sharing_equal_redistribution()
+    test_local_load_sharing_degree_preference()
+    test_local_load_sharing_updates_synchronously()
+    test_local_load_sharing_records_shed_load()
+    test_local_load_sharing_validates_parameters()
     test_legacy_cascading_redistributes_failed_load_once()
     test_legacy_cascading_redistributes_to_functioning_neighbors()
     test_cascading_timeline_length()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -414,6 +414,25 @@ def test_motter_lai_initial_load_and_capacity():
 
 
 
+def test_motter_lai_recomputes_and_fails_synchronously():
+    params = get_simulation_params()
+    params.update({
+        'model': 'motter_lai',
+        'r': 0.1,
+        'k_a': 0,
+        'attack': None,
+        'k_d': 0,
+        'defense': None
+    })
+
+    cf = Cascading(nx.cycle_graph(5), **params)
+    cf.failed = {0}
+
+    failed_new = cf.run_motter_lai_step()
+
+    assert failed_new == {2, 3}
+
+
 def test_crucitti_reference_transition():
     params = get_simulation_params()
     params.update({
@@ -499,6 +518,26 @@ def test_crucitti_uses_weighted_efficient_paths():
 
     assert load[1] == 1
     assert np.isclose(efficiency, 5 / 6)
+
+
+def test_crucitti_uses_most_congested_endpoint():
+    params = get_simulation_params()
+    params.update({
+        'model': 'crucitti',
+        'r': 0.2,
+        'k_a': 0,
+        'attack': None,
+        'k_d': 0,
+        'defense': None
+    })
+
+    cf = Cascading(nx.path_graph(2), **params)
+    cf.load = {0: 2, 1: 4}
+    cf.capacity = {0: 1, 1: 1}
+
+    cf.run_crucitti_step()
+
+    assert cf.graph[0][1]['efficiency'] == 0.25
 
 
 def test_crucitti_validates_parameters():
@@ -859,9 +898,11 @@ def main():
     test_cascading_uses_requested_seed()
     test_cascading_edge_attack_preserves_input_graph()
     test_motter_lai_initial_load_and_capacity()
+    test_motter_lai_recomputes_and_fails_synchronously()
     test_crucitti_reference_transition()
     test_crucitti_restores_edge_efficiency()
     test_crucitti_uses_weighted_efficient_paths()
+    test_crucitti_uses_most_congested_endpoint()
     test_crucitti_validates_parameters()
     test_local_load_sharing_initial_load_and_capacity()
     test_local_load_sharing_equal_redistribution()


### PR DESCRIPTION
## Summary

- add `model='local_load_sharing'` using the Wei–Luo–Zhang local preferential redistribution rule
- make `beta=0` equal sharing and larger `beta` values increasingly favor high-degree functioning neighbors
- use degree-based initial loads with fixed `(1 + r)` capacity, synchronous transfers, and explicit `shed_load` accounting
- retain `legacy_redistribution` for compatibility
- strengthen Motter–Lai and Crucitti conformance regressions
- replace the outdated cascading tutorial and add the Wei citation

## Scientific contract

For a newly failed node `i`, the load sent to functioning neighbor `j` is

`L_i * k_j**beta / sum(k_u**beta for u in functioning_neighbors(i))`.

Degrees are measured on the intact graph. All transfers in a round are accumulated before overload failures are evaluated.

## Tests

Added deterministic checks for:

- degree-based initial load and capacity
- equal sharing at `beta=0`
- degree-proportional sharing at `beta=1`
- synchronous aggregation from simultaneous failures
- stranded-load accounting
- invalid parameter rejection
- Motter–Lai synchronous rerouting failures
- Crucitti's most-congested-endpoint convention

CI is expected to run the repository's supported Python matrix.