### PR TITLE
Make visualization CI FFmpeg setup reliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
           python-version: '3.14'
 
       - name: Install ffmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install --yes ffmpeg
+          ffmpeg -version
 
       - name: Install package and visualization dependencies
         run: |


### PR DESCRIPTION
## Cause

The post-merge `master` workflow failed before tests ran because `FedericoCarboni/setup-ffmpeg@v3` could not fetch its external FFmpeg release. Retrying the failed job reproduced the same `TypeError: fetch failed`. All seven core Python jobs and the package job passed.

## Fix

Replace the third-party setup action with Ubuntu's package manager, use APT download retries, and verify the installed executable with `ffmpeg -version`. The visualization tests themselves are unchanged.

## Scope

CI-only reliability fix. It does not alter TIGER source, tests, documentation, package contents, or the 0.6.0 version.